### PR TITLE
sub vcl_hit missing curly brackets

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -270,11 +270,13 @@ sub vcl_hit {
     if (obj.ttl + 10s > 0s) {
       #set req.http.grace = "normal(limited)";
       return (deliver);
+    }
   } else {
     # backend is sick - use full grace
       if (obj.ttl + obj.grace > 0s) {
-      #set req.http.grace = "full";
-      return (deliver);
+        #set req.http.grace = "full";
+        return (deliver);
+      }
   }
 }
 


### PR DESCRIPTION
varnishd (varnish-6.0.6 revision 29a1a8243dbef3d973aec28dc90403188c1dc8e7)

Error:
Message from VCC-compiler:
Symbol not found.
('/opt/bitnami/varnish/etc/varnish/default.vcl' Line 281 Pos 1)
sub vcl_miss {
###-----------

Running VCC-compiler failed, exited with 2
VCL compilation failed
/opt/bitnami/varnish/scripts/ctl.sh : varnish could not be started